### PR TITLE
Enabled fine tuning of inpainting models

### DIFF
--- a/scripts/configuration_gui.py
+++ b/scripts/configuration_gui.py
@@ -864,7 +864,7 @@ class App(ctk.CTk):
         self.play_cfg = 7.5
         self.play_steps = 25
         self.schedulers = ["DPMSolverMultistepScheduler", "PNDMScheduler", 'DDIMScheduler','EulerAncestralDiscreteScheduler','EulerDiscreteScheduler']
-        self.quick_select_models = ["Stable Diffusion 1.4", "Stable Diffusion 1.5", "Stable Diffusion 2 Base (512)", "Stable Diffusion 2 (768)", 'Stable Diffusion 2.1 Base (512)', "Stable Diffusion 2.1 (768)"]
+        self.quick_select_models = ["Stable Diffusion 1.4", "Stable Diffusion 1.5", "Stable Diffusion 1.5 Inpaint", "Stable Diffusion 2 Base (512)", "Stable Diffusion 2 (768)", 'Stable Diffusion 2.1 Base (512)', "Stable Diffusion 2.1 (768)"]
         self.play_scheduler = 'DPMSolverMultistepScheduler'
         self.pipe = None
         self.current_model = None
@@ -998,6 +998,8 @@ class App(ctk.CTk):
                 self.input_model_path_entry.insert(0,"CompVis/stable-diffusion-v1-4")
             elif val == 'Stable Diffusion 1.5':
                 self.input_model_path_entry.insert(0,"runwayml/stable-diffusion-v1-5")
+            elif val == 'Stable Diffusion 1.5 Inpaint':
+                self.input_model_path_entry.insert(0,"runwayml/stable-diffusion-inpainting")
             elif val == 'Stable Diffusion 2 Base (512)':
                 self.input_model_path_entry.insert(0,"stabilityai/stable-diffusion-2-base")
             elif val == 'Stable Diffusion 2 (768)':

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -38,6 +38,7 @@ from diffusers import AutoencoderKL, DDIMScheduler, DDPMScheduler, DiffusionPipe
 from diffusers.optimization import get_scheduler
 from huggingface_hub import HfFolder, Repository, whoami
 from torchvision import transforms
+from torchvision.transforms import functional
 from tqdm.auto import tqdm
 from transformers import CLIPTextModel, CLIPTokenizer
 from typing import Dict, List, Generator, Tuple
@@ -532,9 +533,14 @@ class AutoBucketing(Dataset):
                 transforms.Normalize([0.5], [0.5]),
             ]
         )
+        self.mask_transforms = transforms.Compose(
+            [
+                transforms.ToTensor(),
+            ]
+        )
         self.seed = seed
         #shared_dataloader = None
-        print(f" {bcolors.WARNING}Creating Auto Bucketing Dataloader{bcolors.ENDC}")   
+        print(f" {bcolors.WARNING}Creating Auto Bucketing Dataloader{bcolors.ENDC}")
 
         shared_dataloader = DataLoaderMultiAspect(concepts_list, debug_level=debug_level,resolution=self.resolution,seed=self.seed, batch_size=self.batch_size, flip_p=flip_p,use_image_names_as_captions=self.use_image_names_as_captions,add_class_images_to_dataset=self.add_class_images_to_dataset,balance_datasets=self.balance_datasets,with_prior_loss=self.with_prior_loss,use_text_files_as_captions=self.use_text_files_as_captions,aspect_mode=self.aspect_mode,action_preference=self.action_preference)
         
@@ -550,11 +556,11 @@ class AutoBucketing(Dataset):
             self.image_train_items = shared_dataloader.get_all_images()
             self.num_train_images = self.num_train_images + len(self.image_train_items)
             self._length = max(math.trunc(self.num_train_images * repeats), batch_size) - self.num_train_images % self.batch_size
-        
+
         print()
-        print(f" {bcolors.WARNING} ** Validation Set: {set}, steps: {self._length / batch_size:.0f}, repeats: {repeats} {bcolors.ENDC}")   
+        print(f" {bcolors.WARNING} ** Validation Set: {set}, steps: {self._length / batch_size:.0f}, repeats: {repeats} {bcolors.ENDC}")
         print()
-        
+
     
     def __len__(self):
         return self._length
@@ -590,8 +596,10 @@ class AutoBucketing(Dataset):
         if class_img==False:
             image_train_tmp = image_train_item.hydrate(crop=False, save=0, crop_jitter=self.crop_jitter)
             image_train_tmp_image = Image.fromarray(self.normalize8(image_train_tmp.image)).convert("RGB")
-            example["instance_images"] = self.image_transforms(image_train_tmp_image)       
-            #print(image_train_tmp.caption)     
+            image_train_tmp_mask = Image.fromarray(self.normalize8(image_train_tmp.mask)).convert("L")
+            example["instance_images"] = self.image_transforms(image_train_tmp_image)
+            example["mask"] = self.mask_transforms(image_train_tmp_mask)
+            #print(image_train_tmp.caption)
             example["instance_prompt_ids"] = self.tokenizer(
                 image_train_tmp.caption,
                 padding="do_not_pad",
@@ -600,7 +608,7 @@ class AutoBucketing(Dataset):
             ).input_ids
             image_train_item.self_destruct()
             return example
-            
+
         if class_img==True:
             image_train_tmp = image_train_item.hydrate(crop=False, save=4, crop_jitter=self.crop_jitter)
             image_train_tmp_image = Image.fromarray(self.normalize8(image_train_tmp.image)).convert("RGB")
@@ -618,89 +626,109 @@ _RANDOM_TRIM = 0.04
 class ImageTrainItem(): 
     """
     image: Image
+    mask: Image
     identifier: caption,
     target_aspect: (width, height), 
     pathname: path to image file
     flip_p: probability of flipping image (0.0 to 1.0)
     """    
-    def __init__(self, image: Image, caption: str, target_wh: list, pathname: str, flip_p=0.0):
+    def __init__(self, image: Image, mask: Image, caption: str, target_wh: list, pathname: str, flip_p=0.0):
         self.caption = caption
         self.target_wh = target_wh
         self.pathname = pathname
+        self.mask_pathname = os.path.splitext(pathname)[0] + "-masklabel.png"
         self.flip_p = flip_p
         self.flip = transforms.RandomHorizontalFlip(p=flip_p)
         self.cropped_img = None
         self.is_dupe = []
+
         if image is None:
             self.image = []
         else:
             self.image = image
+
+        if mask is None:
+            self.mask = []
+        else:
+            self.mask = mask
+
     def self_destruct(self):
         self.image = []
+        self.mask = []
         self.cropped_img = None
         self.is_dupe.append(1)
+
+    def load_image(self, pathname, crop, crop_jitter):
+        if len(self.is_dupe) > 0:
+            chance = float(len(self.is_dupe)) / 10.0
+            self.flip = transforms.RandomHorizontalFlip(p=self.flip_p + chance if chance < 1.0 else 1.0)
+            self.crop_jitter = crop_jitter + (len(self.is_dupe) * 10) if crop_jitter < 50 else 50
+        image = Image.open(pathname).convert('RGB')
+
+        width, height = image.size
+        if crop:
+            cropped_img = self.__autocrop(image)
+            image = cropped_img.resize((512, 512), resample=Image.Resampling.LANCZOS)
+        else:
+            width, height = image.size
+            jitter_amount = random.randint(0, crop_jitter)
+
+            if self.target_wh[0] == self.target_wh[1]:
+                if width > height:
+                    left = random.randint(0, width - height)
+                    image = image.crop((left, 0, height + left, height))
+                    width = height
+                elif height > width:
+                    top = random.randint(0, height - width)
+                    image = image.crop((0, top, width, width + top))
+                    height = width
+                elif width > self.target_wh[0]:
+                    slice = min(int(self.target_wh[0] * _RANDOM_TRIM), width - self.target_wh[0])
+                    slicew_ratio = random.random()
+                    left = int(slice * slicew_ratio)
+                    right = width - int(slice * (1 - slicew_ratio))
+                    sliceh_ratio = random.random()
+                    top = int(slice * sliceh_ratio)
+                    bottom = height - int(slice * (1 - sliceh_ratio))
+
+                    image = image.crop((left, top, right, bottom))
+            else:
+                image_aspect = width / height
+                target_aspect = self.target_wh[0] / self.target_wh[1]
+                if image_aspect > target_aspect:
+                    new_width = int(height * target_aspect)
+                    jitter_amount = max(min(jitter_amount, int(abs(width - new_width) / 2)), 0)
+                    left = jitter_amount
+                    right = left + new_width
+                    image = image.crop((left, 0, right, height))
+                else:
+                    new_height = int(width / target_aspect)
+                    jitter_amount = max(min(jitter_amount, int(abs(height - new_height) / 2)), 0)
+                    top = jitter_amount
+                    bottom = top + new_height
+                    image = image.crop((0, top, width, bottom))
+                    # LAZCOS resample
+            image = image.resize(self.target_wh, resample=Image.Resampling.LANCZOS)
+            # print the pixel count of the image
+            # print path to image file
+            # print(self.pathname)
+            # print(self.image.size[0] * self.image.size[1])
+            image = self.flip(image)
+        return image
+
     def hydrate(self, crop=False, save=False, crop_jitter=20):
         """
         crop: hard center crop to 512x512
         save: save the cropped image to disk, for manual inspection of resize/crop
         crop_jitter: randomly shift cropp by N pixels when using multiple aspect ratios to improve training quality
         """
+
         if not hasattr(self, 'image') or len(self.image) == 0:
-            if len(self.is_dupe) > 0:
-                chance = float(len(self.is_dupe)) / 10.0
-                self.flip = transforms.RandomHorizontalFlip(p=self.flip_p+chance if chance < 1.0 else 1.0)
-                self.crop_jitter = crop_jitter + (len(self.is_dupe) * 10) if crop_jitter < 50 else 50
-            self.image = Image.open(self.pathname).convert('RGB')
-
-            width, height = self.image.size
-            if crop: 
-                cropped_img = self.__autocrop(self.image)
-                self.image = cropped_img.resize((512,512), resample=Image.Resampling.LANCZOS)
+            self.image = self.load_image(self.pathname, crop, crop_jitter)
+            if os.path.exists(self.mask_pathname):
+                self.mask = self.load_image(self.mask_pathname, crop, crop_jitter)
             else:
-                width, height = self.image.size
-                jitter_amount = random.randint(0,crop_jitter)
-
-                if self.target_wh[0] == self.target_wh[1]:
-                    if width > height:
-                        left = random.randint(0, width - height)
-                        self.image = self.image.crop((left, 0, height+left, height))
-                        width = height
-                    elif height > width:
-                        top = random.randint(0, height - width)
-                        self.image = self.image.crop((0, top, width, width+top))
-                        height = width
-                    elif width > self.target_wh[0]:
-                        slice = min(int(self.target_wh[0] * _RANDOM_TRIM), width-self.target_wh[0])
-                        slicew_ratio = random.random()
-                        left = int(slice*slicew_ratio)
-                        right = width-int(slice*(1-slicew_ratio))
-                        sliceh_ratio = random.random()
-                        top = int(slice*sliceh_ratio)
-                        bottom = height- int(slice*(1-sliceh_ratio))
-
-                        self.image = self.image.crop((left, top, right, bottom))
-                else: 
-                    image_aspect = width / height                    
-                    target_aspect = self.target_wh[0] / self.target_wh[1]
-                    if image_aspect > target_aspect:
-                        new_width = int(height * target_aspect)
-                        jitter_amount = max(min(jitter_amount, int(abs(width-new_width)/2)), 0)
-                        left = jitter_amount
-                        right = left + new_width
-                        self.image = self.image.crop((left, 0, right, height))
-                    else:
-                        new_height = int(width / target_aspect)
-                        jitter_amount = max(min(jitter_amount, int(abs(height-new_height)/2)), 0)
-                        top = jitter_amount
-                        bottom = top + new_height
-                        self.image = self.image.crop((0, top, width, bottom))
-                        #LAZCOS resample
-                self.image = self.image.resize(self.target_wh, resample=Image.Resampling.LANCZOS)
-            #print the pixel count of the image
-            #print path to image file
-            #print(self.pathname)
-            #print(self.image.size[0] * self.image.size[1])
-            self.image = self.flip(self.image)
+                self.mask = Image.new('RGB', self.image.size, color="white")
 
         if type(self.image) is not np.ndarray:
             if save: 
@@ -712,7 +740,12 @@ class ImageTrainItem():
             self.image = np.array(self.image).astype(np.uint8)
 
             self.image = (self.image / 127.5 - 1.0).astype(np.float32)
-        
+
+        if type(self.mask) is not np.ndarray:
+            self.mask = np.array(self.mask).astype(np.uint8)
+
+            self.mask = (self.mask / 255.0).astype(np.float32)
+
         #print(self.image.shape)
 
         return self
@@ -851,7 +884,7 @@ class DataLoaderMultiAspect():
 
             target_wh = min(self.aspects, key=lambda aspects:abs(aspects[0]/aspects[1] - image_aspect))
 
-            image_train_item = ImageTrainItem(image=None, caption=identifier, target_wh=target_wh, pathname=pathname, flip_p=flip_p)
+            image_train_item = ImageTrainItem(image=None, mask=None, caption=identifier, target_wh=target_wh, pathname=pathname, flip_p=flip_p)
 
             decorated_image_train_items.append(image_train_item)
         return decorated_image_train_items
@@ -861,7 +894,7 @@ class DataLoaderMultiAspect():
         """
         Put images into buckets based on aspect ratio with batch_size*n images per bucket, discards remainder
         """
-        
+
         # TODO: this is not terribly efficient but at least linear time
         buckets = {}
         for image_caption_pair in prepared_train_data:
@@ -869,7 +902,7 @@ class DataLoaderMultiAspect():
 
             if (target_wh[0],target_wh[1]) not in buckets:
                 buckets[(target_wh[0],target_wh[1])] = []
-            buckets[(target_wh[0],target_wh[1])].append(image_caption_pair) 
+            buckets[(target_wh[0],target_wh[1])].append(image_caption_pair)
         print(f" ** Number of buckets: {len(buckets)}")
         for bucket in buckets:
             bucket_len = len(buckets[bucket])
@@ -896,7 +929,7 @@ class DataLoaderMultiAspect():
                         action = 'truncate'
                 elif batch_size > bucket_len:
                     action = 'add'
-                
+
             elif aspect_mode == 'add':
                 action = 'add'
             elif aspect_mode == 'truncate':
@@ -910,7 +943,7 @@ class DataLoaderMultiAspect():
                 print(f"  ** Bucket {bucket} found {bucket_len}, nice!")
             elif action == 'add':
                 #copy the bucket
-                shuffleBucket = random.sample(buckets[bucket], bucket_len)     
+                shuffleBucket = random.sample(buckets[bucket], bucket_len)
                 #add the images to the bucket
                 current_bucket_size = bucket_len
                 truncate_count = (bucket_len) % batch_size
@@ -937,7 +970,7 @@ class DataLoaderMultiAspect():
         image_caption_pairs = []
         for bucket in buckets:
             image_caption_pairs.extend(buckets[bucket])
-        
+
         return image_caption_pairs
 
     @staticmethod
@@ -947,7 +980,7 @@ class DataLoaderMultiAspect():
             current = os.path.join(recurse_root, f)
             if os.path.isfile(current):
                 ext = os.path.splitext(f)[1].lower()
-                if ext in ['.jpg', '.jpeg', '.png', '.bmp', '.webp']:
+                if ext in ['.jpg', '.jpeg', '.png', '.bmp', '.webp'] and '-masklabel.png' not in f:
                     #try to open the file to make sure it's a valid image
                     try:
                         img = Image.open(current)
@@ -1042,8 +1075,8 @@ class NormalDataset(Dataset):
                 #print(f" {bcolors.WARNING} ** Processing instance images: {recurse_root['instance_data_dir']}{bcolors.ENDC}")
                 concept_token = recurse_root['instance_prompt']
                 data = recurse_root['instance_data_dir']
-            
-            
+
+
         else:
             concept_token = None
         #progress bar
@@ -1186,30 +1219,38 @@ class CachedLatentsDataset(Dataset):
             self.text_encoder = self.empty_tokens
         else:
             self.text_encoder = self.cache.text_encoder_cache[0]
-        
+        self.conditioning_latent_cache = self.cache.conditioning_latent_cache[0]
+        self.mask_cache = self.cache.mask_cache[0]
+
         del self.cache
-        return self.latents, self.text_encoder
+        return self.latents, self.text_encoder, self.conditioning_latent_cache, self.mask_cache
     def add_pt_cache(self, cache_path):
         if len(self.cache_paths) == 0:
             self.cache_paths = (cache_path,)
         else:
             self.cache_paths += (cache_path,)
-        
+
 class LatentsDataset(Dataset):
-    def __init__(self, latents_cache=None, text_encoder_cache=None):
+    def __init__(self, latents_cache=None, text_encoder_cache=None, conditioning_latent_cache=None, mask_cache=None):
         self.latents_cache = latents_cache
         self.text_encoder_cache = text_encoder_cache
-    def add_latent(self, latent, text_encoder):
+        self.conditioning_latent_cache = conditioning_latent_cache
+        self.mask_cache = mask_cache
+    def add_latent(self, latent, text_encoder, cached_conditioning_latent, cached_mask):
         self.latents_cache.append(latent)
         self.text_encoder_cache.append(text_encoder)
+        self.conditioning_latent_cache.append(cached_conditioning_latent)
+        self.mask_cache.append(cached_mask)
     def __len__(self):
         return len(self.latents_cache)
     def __getitem__(self, index):
-        return self.latents_cache[index], self.text_encoder_cache[index]
+        return self.latents_cache[index], self.text_encoder_cache[index], self.conditioning_latent_cache[index], self.mask_cache[index]
     def __add__(self, other):
         latents_cache = self.latents_cache + other.latents_cache
         text_encoder_cache = self.text_encoder_cache + other.text_encoder_cache
-        return LatentsDataset(latents_cache, text_encoder_cache)
+        conditioning_latent_cache = self.conditioning_latent_cache + other.conditioning_latent_cache
+        mask_cache = self.mask_cache + other.mask_cache
+        return LatentsDataset(latents_cache, text_encoder_cache, conditioning_latent_cache, mask_cache)
 class AverageMeter:
     def __init__(self, name=None):
         self.name = name
@@ -1499,12 +1540,14 @@ def main():
         #print('test')
         input_ids = [example["instance_prompt_ids"] for example in examples]
         pixel_values = [example["instance_images"] for example in examples]
+        mask = [example["mask"] for example in examples]
         #print('test')
         # Concat class and instance examples for prior preservation.
         # We do this to avoid doing two forward passes.
         if args.with_prior_preservation:
             input_ids += [example["class_prompt_ids"] for example in examples]
             pixel_values += [example["class_images"] for example in examples]
+            mask += [example["mask"] for example in examples]
         ### no need to do it now when it's loaded by the multiAspectsDataset
         #if args.with_prior_preservation:
         #    input_ids += [example["class_prompt_ids"] for example in examples]
@@ -1516,17 +1559,18 @@ def main():
 
         pixel_values = torch.stack(pixel_values)
         pixel_values = pixel_values.to(memory_format=torch.contiguous_format).float()
-        
+
         input_ids = tokenizer.pad(
             {"input_ids": input_ids},
             padding="max_length",
             max_length=tokenizer.model_max_length,
             return_tensors="pt",\
             ).input_ids
-            
+        mask = torch.stack(mask)
         batch = {
             "input_ids": input_ids,
             "pixel_values": pixel_values,
+            "mask": mask,
         }
         return batch
 
@@ -1578,6 +1622,9 @@ def main():
     if not args.train_text_encoder:
         text_encoder.to(accelerator.device, dtype=weight_dtype)
 
+    buckets_wh = set([tuple(x.target_wh) for x in train_dataset.image_train_items])
+    mask_latent = {shape: vae.encode(torch.zeros(1, 3, shape[1], shape[0]).to(accelerator.device, dtype=weight_dtype)).latent_dist.mean * 0.18215 for shape in buckets_wh}
+
     cached_dataset = CachedLatentsDataset(batch_size=args.train_batch_size,tokenizer=tokenizer,conditional_dropout=args.conditional_dropout,accelerator=accelerator,dtype=weight_dtype)
     gen_cache = False
     data_len = len(train_dataloader)
@@ -1593,7 +1640,7 @@ def main():
             files = os.listdir(latent_cache_dir)
             gen_cache = True
             for file in files:
-                os.remove(os.path.join(latent_cache_dir,file))     
+                os.remove(os.path.join(latent_cache_dir,file))
     if gen_cache == False :
         print(f" {bcolors.OKGREEN}Loading Latent Cache from {latent_cache_dir}{bcolors.ENDC}")
         del vae
@@ -1606,33 +1653,38 @@ def main():
             cached_dataset.add_pt_cache(os.path.join(latent_cache_dir,f"latents_cache_{i}.pt"))
     if gen_cache == True:
         #delete all the cached latents if they exist to avoid problems
-        print(f" {bcolors.WARNING}Generating latents cache...{bcolors.ENDC}") 
-        train_dataset = LatentsDataset([], [])
+        print(f" {bcolors.WARNING}Generating latents cache...{bcolors.ENDC}")
+        train_dataset = LatentsDataset([], [], [], [])
         counter = 0
         with torch.no_grad():
             for batch in tqdm(train_dataloader, desc="Caching latents", bar_format='%s{l_bar}%s%s{bar}%s%s{r_bar}%s'%(bcolors.OKBLUE,bcolors.ENDC, bcolors.OKBLUE, bcolors.ENDC,bcolors.OKBLUE,bcolors.ENDC,)):
                 batch["pixel_values"] = batch["pixel_values"].to(accelerator.device, non_blocking=True, dtype=weight_dtype)
                 batch["input_ids"] = batch["input_ids"].to(accelerator.device, non_blocking=True)
-                
+                batch["mask"] = batch["mask"].to(accelerator.device, non_blocking=True, dtype=weight_dtype)
+
                 cached_latent = vae.encode(batch["pixel_values"]).latent_dist
                 if args.train_text_encoder:
                     cached_text_enc = batch["input_ids"]
                 else:
                     cached_text_enc = text_encoder(batch["input_ids"])[0]
-                train_dataset.add_latent(cached_latent, cached_text_enc)
+                cached_conditioning_latent = vae.encode(batch["pixel_values"] * (1 - batch["mask"])).latent_dist
+                cached_mask = functional.resize(batch["mask"], size=cached_conditioning_latent.mean.shape[2:])
+                train_dataset.add_latent(cached_latent, cached_text_enc, cached_conditioning_latent, cached_mask)
                 del batch
                 del cached_latent
                 del cached_text_enc
+                del cached_conditioning_latent
+                del cached_mask
                 torch.save(train_dataset, os.path.join(latent_cache_dir,f"latents_cache_{counter}.pt"))
                 cached_dataset.add_pt_cache(os.path.join(latent_cache_dir,f"latents_cache_{counter}.pt"))
                 counter += 1
-                train_dataset = LatentsDataset([], [])
+                train_dataset = LatentsDataset([], [], [], [])
                 #if counter % 300 == 0:
                     #train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=1, collate_fn=lambda x: x, shuffle=False)
                 #    gc.collect()
                 #    torch.cuda.empty_cache()
                 #    accelerator.free_memory()
-                    
+
         #clear vram after caching latents
         del vae
         if not args.train_text_encoder:
@@ -1903,15 +1955,17 @@ def main():
                         #convert sampleIndex to number in words
                         sampleName = f"prompt_{sampleIndex+1}"
                         os.makedirs(os.path.join(sample_dir,sampleName), exist_ok=True)
+                        conditioning_image = torch.zeros(1, 3, width, height)
+                        mask = torch.ones(1, 1, width, height)
                         for i in tqdm(range(args.n_save_sample) if not args.save_sample_controlled_seed else range(args.n_save_sample+len(args.save_sample_controlled_seed)), desc="Generating samples"):
                             #check if the sample is controlled by a seed
                             if i != args.n_save_sample:
-                                images = pipeline(samplePrompt,height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps).images
+                                images = pipeline(samplePrompt, conditioning_image, mask, height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps).images
                                 images[0].save(os.path.join(sample_dir,sampleName, f"{sampleName}_{i}.png"))
                             else:
                                 for seed in args.save_sample_controlled_seed:
                                     generator = torch.Generator("cuda").manual_seed(seed)
-                                    images = pipeline(samplePrompt,height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps, generator=generator).images
+                                    images = pipeline(samplePrompt,conditioning_image, mask,height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps, generator=generator).images
                                     images[0].save(os.path.join(sample_dir,sampleName, f"{sampleName}_controlled_seed_{str(seed)}.png"))
                         if args.send_telegram_updates:
                             imgs = []
@@ -2079,8 +2133,11 @@ def main():
                 with accelerator.accumulate(unet):
                     # Convert images to latent space
                     with torch.no_grad():
-                            latent_dist = batch[0][0]
-                            latents = latent_dist.sample() * 0.18215
+                        latent_dist = batch[0][0]
+                        conditioning_latent_dist = batch[0][2]
+                        mask = batch[0][3]
+                        latents = latent_dist.sample() * 0.18215
+                        conditioning_latents = conditioning_latent_dist.sample() * 0.18215
 
                     # Sample noise that we'll add to the latents
                     noise = torch.randn_like(latents)
@@ -2105,8 +2162,14 @@ def main():
                             encoder_hidden_states = batch[0][1]
 
                     # Predict the noise residual
-                    #noise_pred = unet(noisy_latents, timesteps, encoder_hidden_states).sample
-                    model_pred = unet(noisy_latents, timesteps, encoder_hidden_states).sample
+
+                    if random.uniform(0, 1) < 0.25:
+                        # for some steps, predict the unmasked image
+                        conditioning_latents = torch.stack([mask_latent[tuple([latents.shape[3]*8, latents.shape[2]*8])].squeeze()] * bsz)
+                        mask = torch.ones(bsz, 1, latents.shape[2], latents.shape[3]).to(accelerator.device, dtype=weight_dtype)
+
+                    noisy_inpaint_latents = torch.concat([noisy_latents, mask, conditioning_latents], 1)
+                    model_pred = unet(noisy_inpaint_latents, timesteps, encoder_hidden_states).sample
 
                     # Get the target for loss depending on the prediction type
                     if noise_scheduler.config.prediction_type == "epsilon":


### PR DESCRIPTION
Not a fully featured implementation, but all basic functionality should be ready.

Known issues:
- Fine tuning of normal models is broken with this version

Only tested with the runwayml 1.5 inpainting model: https://huggingface.co/runwayml/stable-diffusion-inpainting.

The method:

The model has 5 additional input channels. 4 for the latent representation of the unmasked parts of the image, and 1 channel for the downscaled mask. For each sample image, two new values are added to the latent cache:
1. The mask, downscaled to the same resolution as the latent image representation
2. The latent representation of the image where the masked parts are blacked out.

The mask can optionally be loaded from a png file with the same name as the image, and an added "-masklabel" postfix. If the file is named `x.jpg`, the mask is named `x-masklabel.png`. If no mask is provided, the entire image is automatically masked with a fully white mask.

During training, 25% of steps skip the masking part, and train on a fully blocked out image. This is the same method that was used to train the original inpainting checkpoint.