### PR TITLE
Handle checkpoints which aren't wrapped in a state_dict when converting a ckpt.

### DIFF
--- a/scripts/configuration_gui.py
+++ b/scripts/configuration_gui.py
@@ -2543,7 +2543,8 @@ class App(ctk.CTk):
             else:
                 prediction = "epsilon"
             key_name = "model.diffusion_model.input_blocks.2.1.transformer_blocks.0.attn2.to_k.weight"
-            checkpoint = checkpoint["state_dict"]
+            if "state_dict" in checkpoint.keys():
+                checkpoint = checkpoint["state_dict"]
             if key_name in checkpoint and checkpoint[key_name].shape[-1] == 1024:
                 version = "v2"
             else:


### PR DESCRIPTION
Some ckpt files, such as those created by the automatic1111 webui's checkpoint merger, have weights that aren't wrapped in a state_dict. Handle that.