### PR TITLE
Gradient accumulation fix

### DIFF
--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -1955,7 +1955,7 @@ def main():
     print(f" {bcolors.OKGREEN}Latents are ready.{bcolors.ENDC}")
     # Scheduler and math around the number of training steps.
     overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps) * args.gradient_accumulation_steps
     if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
         overrode_max_train_steps = True
@@ -1963,8 +1963,8 @@ def main():
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps,
-        num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+        num_warmup_steps=args.lr_warmup_steps,
+        num_training_steps=args.max_train_steps,
     )
 
     if args.train_text_encoder and not args.use_ema:
@@ -1985,9 +1985,9 @@ def main():
         )
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps) * args.gradient_accumulation_steps
     if overrode_max_train_steps:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch * args.gradient_accumulation_steps
+        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
         #print(args.max_train_steps, num_update_steps_per_epoch)
     # Afterwards we recalculate our number of training epochs
     #print(args.max_train_steps, num_update_steps_per_epoch)

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -2445,7 +2445,7 @@ def main():
             progress_bar_inter_epoch.set_description("Steps To Epoch")
             progress_bar_inter_epoch.reset(total=num_update_steps_per_epoch)
             for step, batch in enumerate(train_dataloader):
-                with accelerator.accumulate(unet):
+                with accelerator.accumulate(unet), (accelerator.accumulate(text_encoder) if args.train_text_encoder else nullcontext()):
                     # Convert images to latent space
                     with torch.no_grad():
 

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -2445,7 +2445,7 @@ def main():
             progress_bar_inter_epoch.set_description("Steps To Epoch")
             progress_bar_inter_epoch.reset(total=num_update_steps_per_epoch)
             for step, batch in enumerate(train_dataloader):
-                with accelerator.accumulate(unet), (accelerator.accumulate(text_encoder) if args.train_text_encoder else nullcontext()):
+                with accelerator.accumulate(unet):
                     # Convert images to latent space
                     with torch.no_grad():
 

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -1963,7 +1963,7 @@ def main():
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps,
+        num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps,
         num_training_steps=args.max_train_steps,
     )
 


### PR DESCRIPTION
Currently the calculation for `num_update_steps_per_epoch` is incorrect when `args.gradient_accumulation_steps` > 0, resulting in the calculated `num_train_epochs` being too large by a factor of `gradient_accumulation_steps`. Because gradient accumulation is handled inside `accumulator` the fix is to just ignore gradient accumulation and count steps normally, aside from rounding down the number of steps per epoch to the accumulation step count.