### PR TITLE
Allow specifying lr_warmup_steps as a fraction

### DIFF
--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -323,7 +323,7 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        "--lr_warmup_steps", type=int, default=500, help="Number of steps for the warmup in the lr scheduler."
+        "--lr_warmup_steps", type=float, default=500, help="Number of steps for the warmup in the lr scheduler."
     )
     parser.add_argument(
         "--use_8bit_adam", action="store_true", help="Whether or not to use 8-bit Adam from bitsandbytes."
@@ -1977,6 +1977,9 @@ def main():
     if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
         overrode_max_train_steps = True
+        
+    if args.lr_warmup_steps < 1:
+        args.lr_warmup_steps = math.floor(args.lr_warmup_steps * args.max_train_steps / args.gradient_accumulation_steps)
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,


### PR DESCRIPTION
Useful for doing triangular learning rate schedules, with linear warmup for a fixed fraction of the training run followed by linear decay.