### PR TITLE
Masked improvements

### DIFF
--- a/scripts/captionBuddy.py
+++ b/scripts/captionBuddy.py
@@ -725,6 +725,7 @@ class ImageBrowser(ctk.CTkToplevel):
             self.caption = self.caption +', ' + self.suffix_var
         else:
             self.caption = self.caption + self.suffix_var
+        self.caption = self.caption.strip()
         if self.output_folder != self.folder:
             outputFolder = self.output_folder
         else:

--- a/scripts/captionBuddy.py
+++ b/scripts/captionBuddy.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from tkinter import ttk, Menu
 import os
 import subprocess
-from PIL import Image, ImageTk
+from PIL import Image, ImageTk, ImageDraw
 import tkinter.filedialog as fd
 import json
 import sys
@@ -141,6 +141,11 @@ class ImageBrowser(ctk.CTkToplevel):
         self.mainProcess = mainProcess
         self.captioner_folder = os.path.dirname(os.path.realpath(__file__))
         self.clip_seg = None
+        self.PILimage = None
+        self.PILmask = None
+        self.mask_draw_x = 0
+        self.mask_draw_y = 0
+        self.mask_draw_radius = 20
         #self = master
         #self.overrideredirect(True)
         #self.title_bar = TitleBar(self)
@@ -224,17 +229,25 @@ class ImageBrowser(ctk.CTkToplevel):
         self.destroy()
     def create_widgets(self):
         self.output_folder = ''
-        self.auto_generate_caption_text_override = tk.BooleanVar(self.top_subframe)
-        self.auto_generate_caption_text_override.set(False)
-        self.auto_generate_caption_checkbox_text_override = ctk.CTkCheckBox(self.top_subframe, text="Skip Auto Generate If Text Caption Exists", variable=self.auto_generate_caption_text_override,width=50)
-        self.auto_generate_caption_checkbox_text_override.grid(row=0,column=1,sticky="w",padx=10)
-        #self.auto_generate_caption_checkbox_text_override.pack(side="left", fill="x",expand=True)
-        #add a checkbox to toggle auto generate caption
+
+        # add a checkbox to toggle auto generate caption
         self.auto_generate_caption = tk.BooleanVar(self.top_subframe)
         self.auto_generate_caption.set(True)
         self.auto_generate_caption_checkbox = ctk.CTkCheckBox(self.top_subframe, text="Auto Generate Caption", variable=self.auto_generate_caption,width=50)
-        self.auto_generate_caption_checkbox.grid(row=0,column=0,sticky="e",padx=10)
-        #self.auto_generate_caption_checkbox.pack(side="left", fill="x",expand=True,anchor="w")
+        self.auto_generate_caption_checkbox.pack(side="left", fill="x", expand=True, padx=10)
+
+        # add a checkbox to skip auto generating captions if they already exist
+        self.auto_generate_caption_text_override = tk.BooleanVar(self.top_subframe)
+        self.auto_generate_caption_text_override.set(False)
+        self.auto_generate_caption_checkbox_text_override = ctk.CTkCheckBox(self.top_subframe, text="Skip Auto Generate If Text Caption Exists", variable=self.auto_generate_caption_text_override,width=50)
+        self.auto_generate_caption_checkbox_text_override.pack(side="left", fill="x", expand=True, padx=10)
+
+        # add a checkbox to enable mask editing
+        self.enable_mask_editing = tk.BooleanVar(self.top_subframe)
+        self.enable_mask_editing.set(False)
+        self.enable_mask_editing_checkbox = ctk.CTkCheckBox(self.top_subframe, text="Enable Mask Editing", variable=self.enable_mask_editing, width=50)
+        self.enable_mask_editing_checkbox.pack(side="left", fill="x", expand=True, padx=10)
+
         self.open_button = ctk.CTkButton(self.top_frame,text="Load Folder",fg_color=("gray75", "gray25"), command=self.open_folder,width=50)
         #self.open_button.grid(row=0, column=1)
         self.open_button.pack(side="left", fill="x",expand=True,padx=10)
@@ -260,6 +273,11 @@ class ImageBrowser(ctk.CTkToplevel):
 
         self.image_label = ctk.CTkLabel(self.canvas,text='',width=100,height=100)
         self.image_label.grid(row=0, column=0, sticky="nsew")
+        #self.image_label.bind("<Button-3>", self.click_canvas)
+        self.image_label.bind("<Motion>", self.draw_mask)
+        self.image_label.bind("<Button-1>", self.draw_mask)
+        self.image_label.bind("<Button-3>", self.draw_mask)
+        self.image_label.bind("<MouseWheel>", self.draw_mask_radius)
         #self.image_label.pack(side="top")
         #previous button
         self.prev_button = ctk.CTkButton(self.frame,text="Previous", command= lambda event=None: self.prev_image(event),width=50)
@@ -271,8 +289,8 @@ class ImageBrowser(ctk.CTkToplevel):
         #grid
         self.caption_entry.grid(row=1, column=1, rowspan=3, sticky="nsew",pady=10)
         #bind to enter key
-        self.caption_entry.bind("<Return>", self.save_caption)
-        self.canvas.bind("<Return>", self.save_caption)
+        self.caption_entry.bind("<Return>", self.save)
+        self.canvas.bind("<Return>", self.save)
         self.caption_entry.bind("<Alt-Right>", self.next_image)
         self.caption_entry.bind("<Alt-Left>", self.prev_image)
         self.caption_entry.bind("<Control-BackSpace>", self.delete_word)
@@ -288,7 +306,7 @@ class ImageBrowser(ctk.CTkToplevel):
         self.replace_label.grid(row=0, column=0, sticky="w",padx=5)
         self.replace_entry = ctk.CTkEntry(self.bottom_frame,   )
         self.replace_entry.grid(row=0, column=1, sticky="nsew",padx=5)
-        self.replace_entry.bind("<Return>", self.save_caption)
+        self.replace_entry.bind("<Return>", self.save)
         #self.replace_entry.bind("<Tab>", self.replace)
         #with label
         #create with string variable
@@ -296,7 +314,7 @@ class ImageBrowser(ctk.CTkToplevel):
         self.with_label.grid(row=0, column=2, sticky="w",padx=5)
         self.with_entry = ctk.CTkEntry(self.bottom_frame,   )
         self.with_entry.grid(row=0, column=3,  sticky="nswe",padx=5)
-        self.with_entry.bind("<Return>", self.save_caption)
+        self.with_entry.bind("<Return>", self.save)
         #add another entry with label, add suffix
         
         #create prefix string var
@@ -304,14 +322,14 @@ class ImageBrowser(ctk.CTkToplevel):
         self.prefix_label.grid(row=0, column=4, sticky="w",padx=5)
         self.prefix_entry = ctk.CTkEntry(self.bottom_frame,   )
         self.prefix_entry.grid(row=0, column=5, sticky="nsew",padx=5)
-        self.prefix_entry.bind("<Return>", self.save_caption)
+        self.prefix_entry.bind("<Return>", self.save)
 
         #create suffix string var
         self.suffix_label = ctk.CTkLabel(self.bottom_frame, text="Add to end:")
         self.suffix_label.grid(row=0, column=6, sticky="w",padx=5)
         self.suffix_entry = ctk.CTkEntry(self.bottom_frame,   )
         self.suffix_entry.grid(row=0, column=7, sticky="nsew",padx=5)
-        self.suffix_entry.bind("<Return>", self.save_caption)
+        self.suffix_entry.bind("<Return>", self.save)
         self.all_entries = [self.replace_entry, self.with_entry, self.suffix_entry, self.caption_entry, self.prefix_entry]
         #bind right click menu to all entries
         for entry in self.all_entries:
@@ -538,6 +556,68 @@ class ImageBrowser(ctk.CTkToplevel):
         self.load_image()
         self.caption_entry.focus_set()
 
+    def draw_mask(self, event):
+        if not self.enable_mask_editing.get():
+            return
+
+        if event.widget != self.image_label.children["!label"]:
+            return
+
+        start_x = int(event.x / self.image_size[0] * self.PILimage.width)
+        start_y = int(event.y / self.image_size[1] * self.PILimage.height)
+        end_x = int(self.mask_draw_x / self.image_size[0] * self.PILimage.width)
+        end_y = int(self.mask_draw_y / self.image_size[1] * self.PILimage.height)
+
+        self.mask_draw_x = event.x
+        self.mask_draw_y = event.y
+
+        color = None
+
+        if event.state & 0x0100 or event.num == 1:  # left mouse button
+            color = (255, 255, 255)
+        elif event.state & 0x0400 or event.num == 3:  # right mouse button
+            color = (0, 0, 0)
+
+        if color is not None:
+            if self.PILmask is None:
+                self.PILmask = Image.new('RGB', size=self.PILimage.size, color=(0, 0, 0))
+
+            draw = ImageDraw.Draw(self.PILmask)
+            draw.line((start_x, start_y, end_x, end_y), fill=color, width=self.mask_draw_radius + self.mask_draw_radius + 1)
+            draw.ellipse((start_x - self.mask_draw_radius, start_y - self.mask_draw_radius, start_x + self.mask_draw_radius, start_y + self.mask_draw_radius), fill=color, outline=None)
+            draw.ellipse((end_x - self.mask_draw_radius, end_y - self.mask_draw_radius, end_x + self.mask_draw_radius, end_y + self.mask_draw_radius), fill=color, outline=None)
+
+            self.compose_masked_image()
+            self.display_image()
+
+    def draw_mask_radius(self, event):
+        if event.widget != self.image_label.children["!label"]:
+            return
+
+        delta = -np.sign(event.delta) * 5
+        self.mask_draw_radius += delta
+
+    def compose_masked_image(self):
+        np_image = np.array(self.PILimage).astype(np.float32) / 255.0
+        np_mask = np.array(self.PILmask).astype(np.float32) / 255.0
+        np_mask = np.clip(np_mask, 0.4, 1.0)
+        np_masked_image = (np_image * np_mask * 255.0).astype(np.uint8)
+        self.image = Image.fromarray(np_masked_image, mode='RGB')
+
+    def display_image(self):
+        #resize to fit 600x600 while maintaining aspect ratio
+        width, height = self.image.size
+        if width > height:
+            new_width = 600
+            new_height = int(600 * height / width)
+        else:
+            new_height = 600
+            new_width = int(600 * width / height)
+        self.image_size = (new_width, new_height)
+        self.image = self.image.resize(self.image_size, Image.Resampling.LANCZOS)
+        self.image = ctk.CTkImage(self.image, size=self.image_size)
+        self.image_label.configure(image=self.image)
+
     def load_image(self):
         try:
             self.PILimage = Image.open(self.image_list[self.image_index]).convert('RGB')
@@ -556,14 +636,11 @@ class ImageBrowser(ctk.CTkToplevel):
         self.image = self.PILimage.copy()
 
         try:
+            self.PILmask = None
             mask_filename = os.path.splitext(self.image_list[self.image_index])[0] + '-masklabel.png'
             if os.path.exists(mask_filename):
-                mask = Image.open(mask_filename).convert('RGB')
-                np_image = np.array(self.image).astype(np.float32)/255.0
-                np_mask = np.array(mask).astype(np.float32)/255.0
-                np_mask = np.clip(np_mask, 0.4, 1.0)
-                np_masked_image = (np_image * np_mask * 255.0).astype(np.uint8)
-                self.image = Image.fromarray(np_masked_image, mode='RGB')
+                self.PILmask = Image.open(mask_filename).convert('RGB')
+                self.compose_masked_image()
         except Exception as e:
             print(f'Error opening mask for {self.image_list[self.image_index]}')
             print('Logged path to bad_files.txt')
@@ -576,20 +653,8 @@ class ImageBrowser(ctk.CTkToplevel):
                     f.write(self.image_list[self.image_index]+'\n')
             return
 
-        #print(self.image_list[self.image_index])
-        #self.image = self.image.resize((600, 600), Image.ANTIALIAS)
-        #resize to fit 600x600 while maintaining aspect ratio
-        width, height = self.image.size
-        if width > height:
-            new_width = 600
-            new_height = int(600 * height / width)
-        else:
-            new_height = 600
-            new_width = int(600 * width / height)
-        self.image = self.image.resize((new_width, new_height), Image.Resampling.LANCZOS)
-        self.image = ctk.CTkImage(self.image, size=(new_width, new_height))
-        #print(self.image)
-        self.image_label.configure(image=self.image)
+        self.display_image()
+
         self.caption_file_path = self.image_list[self.image_index]
         self.caption_file_name = os.path.basename(self.caption_file_path)
         self.caption_file_ext = os.path.splitext(self.caption_file_name)[1]
@@ -626,11 +691,18 @@ class ImageBrowser(ctk.CTkToplevel):
             #change the caption entry color to red
             self.caption_entry.configure(fg_color='red')
 
-            
-    def save_caption(self, event):
-        
-        
+    def save(self, event):
+        self.save_caption()
 
+        if self.enable_mask_editing.get():
+            self.save_mask()
+
+    def save_mask(self):
+        mask_filename = os.path.splitext(self.image_list[self.image_index])[0] + '-masklabel.png'
+        if self.PILmask is not None:
+            self.PILmask.save(mask_filename)
+
+    def save_caption(self):
         self.caption = self.caption_entry.get()
         self.replace = self.replace_entry.get()
         self.replace_with = self.with_entry.get()

--- a/scripts/configuration_gui.py
+++ b/scripts/configuration_gui.py
@@ -146,7 +146,7 @@ class ConceptWidget(ctk.CTkFrame):
                         import random
                         
                         #filter files for images
-                        files = [f for f in files if f.endswith(".jpg") or f.endswith(".png") or f.endswith(".jpeg")]
+                        files = [f for f in files if (f.endswith(".jpg") or f.endswith(".png") or f.endswith(".jpeg")) and not f.endswith("-masklabel.png") and not f.endswith("-depth.png")]
                         if len(files) != 0:
                             rand = random.choice(files)
                             image_path = rand
@@ -159,20 +159,20 @@ class ConceptWidget(ctk.CTkFrame):
                             image_to_add = Image.open(image_path)
                             #resize the image to 38x38
                             #resize to 150x150 closest to the original aspect ratio
-                            image_to_add.thumbnail((150, 150), Image.Resampling.LANCZOS)
+                            image_to_add.thumbnail((75, 75), Image.Resampling.LANCZOS)
                             #decide where to put the image
                             if i == 0:
                                 #top left
                                 image.paste(image_to_add, (0, 0))
                             elif i == 1:
                                 #top right
-                                image.paste(image_to_add, (76, 0))
+                                image.paste(image_to_add, (75, 0))
                             elif i == 2:
                                 #bottom left
-                                image.paste(image_to_add, (0, 76))
+                                image.paste(image_to_add, (0, 75))
                             elif i == 3:
                                 #bottom right
-                                image.paste(image_to_add, (76, 76))
+                                image.paste(image_to_add, (75, 75))
                     image = add_corners(image, 30)
                         #convert the image to a photoimage
                         #image.show()

--- a/scripts/configuration_gui.py
+++ b/scripts/configuration_gui.py
@@ -844,7 +844,11 @@ class App(ctk.CTk):
         self.attention_types = ['xformers','Flash Attention']
         self.model_variant = 'Regular'
         self.model_variants = ['Regular', 'Inpaint','Depth2Img']
+        self.masked_training = False
+        self.normalize_masked_area_loss = True
+        self.unmasked_probability = '0%'
         self.fallback_mask_prompt = ''
+        self.max_denoising_strength = '100%'
         self.required_folders = ["vae", "unet", "tokenizer", "text_encoder"]
         self.aspect_ratio_bucketing_mode = 'Dynamic Fill'
         self.dynamic_bucketing_mode = 'Duplicate'
@@ -1669,13 +1673,50 @@ class App(ctk.CTk):
         self.shuffle_dataset_per_epoch_checkbox = ctk.CTkSwitch(self.dataset_frame_subframe, variable=self.shuffle_dataset_per_epoch_var)
         self.shuffle_dataset_per_epoch_checkbox.grid(row=1, column=3, sticky="nsew")
 
-        #option menu to select dynamic bucketing mode (if enabled)
+        #masked training
+        self.masked_training_var = tk.IntVar()
+        self.masked_training_label = ctk.CTkLabel(self.dataset_frame_subframe, text="Masked Training")
+        masked_training_label_ttp = CreateToolTip(self.masked_training_label, "Enable training on masked areas of the dataset.")
+        self.masked_training_checkbox = ctk.CTkSwitch(self.dataset_frame_subframe, variable=self.masked_training_var)
+        self.masked_training_var.set(self.masked_training)
+        self.masked_training_label.grid(row=2, column=2, sticky="nsew")
+        self.masked_training_checkbox.grid(row=2, column=3, sticky="nsew")
+
+        #normalize masked area loss
+        self.normalize_masked_area_loss_var = tk.IntVar()
+        self.normalize_masked_area_loss_label = ctk.CTkLabel(self.dataset_frame_subframe, text="Normalize Masked Area Loss")
+        normalize_masked_area_loss_label_ttp = CreateToolTip(self.normalize_masked_area_loss_label, "Normalize loss values based on the masked area of images.")
+        self.normalize_masked_area_loss_checkbox = ctk.CTkSwitch(self.dataset_frame_subframe, variable=self.normalize_masked_area_loss_var)
+        self.normalize_masked_area_loss_var.set(self.normalize_masked_area_loss)
+        self.normalize_masked_area_loss_label.grid(row=3, column=2, sticky="nsew")
+        self.normalize_masked_area_loss_checkbox.grid(row=3, column=3, sticky="nsew")
+
+        #unmasked probability
+        self.unmasked_probability_var = tk.StringVar()
+        self.unmasked_probability_label = ctk.CTkLabel(self.dataset_frame_subframe, text="Unmasked Steps")
+        unmasked_probability_label_ttp = CreateToolTip(self.unmasked_probability_label, "Fraction of steps to train on unmasked images.")
+        self.unmasked_probability_var.set(self.unmasked_probability)
+        self.unmasked_probability_entry = ctk.CTkEntry(self.dataset_frame_subframe, textvariable=self.unmasked_probability_var)
+        self.unmasked_probability_label.grid(row=4, column=2, sticky="nsew")
+        self.unmasked_probability_entry.grid(row=4, column=3, sticky="nsew")
+
+        #unmasked probability
+        self.max_denoising_strength_var = tk.StringVar()
+        self.max_denoising_strength_label = ctk.CTkLabel(self.dataset_frame_subframe, text="Max Denoising Strength")
+        max_denoising_strength_label_ttp = CreateToolTip(self.max_denoising_strength_label, "Max denoising factor to train on. Set this to 70%-80% for masked training and to reduce overfitting. 100% is the default behavior for training on up to fully noisy images.")
+        self.max_denoising_strength_var.set(self.max_denoising_strength)
+        self.max_denoising_strength_entry = ctk.CTkEntry(self.dataset_frame_subframe, textvariable=self.max_denoising_strength_var)
+        self.max_denoising_strength_label.grid(row=5, column=2, sticky="nsew")
+        self.max_denoising_strength_entry.grid(row=5, column=3, sticky="nsew")
+
+        #fallback mask prompt
         self.fallback_mask_prompt_label = ctk.CTkLabel(self.dataset_frame_subframe, text="Fallback Mask Prompt")
-        fallback_mask_prompt_label_ttp = CreateToolTip(self.fallback_mask_prompt_label, "A prompt used for masking images without a mask. Only used when training inpainting models.")
+        fallback_mask_prompt_label_ttp = CreateToolTip(self.fallback_mask_prompt_label, "A prompt used for masking images without a mask.")
         self.fallback_mask_prompt_entry = ctk.CTkEntry(self.dataset_frame_subframe)
         self.fallback_mask_prompt_entry.insert(0, self.fallback_mask_prompt)
-        self.fallback_mask_prompt_label.grid(row=2, column=2, sticky="nsew")
-        self.fallback_mask_prompt_entry.grid(row=2, column=3, sticky="nsew")
+        self.fallback_mask_prompt_label.grid(row=6, column=2, sticky="nsew")
+        self.fallback_mask_prompt_entry.grid(row=6, column=3, sticky="nsew")
+
         #add download dataset entry
         #add a switch to duplicate fill bucket
         #self.duplicate_fill_buckets_var = tk.IntVar()
@@ -3021,6 +3062,10 @@ class App(ctk.CTk):
         configure['aspect_ratio_bucketing_mode'] = self.aspect_ratio_bucketing_mode_var.get()
         configure['dynamic_bucketing_mode'] = self.dynamic_bucketing_mode_var.get()
         configure['model_variant'] = self.model_variant_var.get()
+        configure['masked_training'] = self.masked_training_var.get()
+        configure['normalize_masked_area_loss'] = self.normalize_masked_area_loss_var.get()
+        configure['unmasked_probability'] = self.unmasked_probability_var.get()
+        configure['max_denoising_strength'] = self.max_denoising_strength_var.get()
         configure['fallback_mask_prompt'] = self.fallback_mask_prompt_entry.get()
         configure['attention'] = self.attention_var.get()
         configure['batch_prompt_sampling'] = int(self.batch_prompt_sampling_optionmenu_var.get())
@@ -3166,6 +3211,10 @@ class App(ctk.CTk):
             self.dynamic_bucketing_mode_label.configure(state='disabled')
             self.dynamic_bucketing_mode_option_menu.configure(state='disabled')
         self.model_variant_var.set(configure["model_variant"])
+        self.masked_training_var.set(configure["masked_training"])
+        self.normalize_masked_area_loss_var.set(configure["normalize_masked_area_loss"])
+        self.unmasked_probability_var.set(configure["unmasked_probability"])
+        self.max_denoising_strength_var.set(configure["max_denoising_strength"])
         self.fallback_mask_prompt_entry.delete(0, tk.END)
         self.fallback_mask_prompt_entry.insert(0, configure["fallback_mask_prompt"])
         self.aspect_ratio_bucketing_mode_var.set(configure["aspect_ratio_bucketing_mode"])
@@ -3234,6 +3283,10 @@ class App(ctk.CTk):
         self.aspect_ratio_bucketing_mode = self.aspect_ratio_bucketing_mode_var.get()
         self.dynamic_bucketing_mode = self.dynamic_bucketing_mode_var.get()
         self.model_variant = self.model_variant_var.get()
+        self.masked_training = self.masked_training_var.get()
+        self.normalize_masked_area_loss = self.normalize_masked_area_loss_var.get()
+        self.unmasked_probability = self.unmasked_probability_var.get()
+        self.max_denoising_strength = self.max_denoising_strength_var.get()
         self.fallback_mask_prompt = self.fallback_mask_prompt_entry.get()
         self.attention = self.attention_var.get()
         self.batch_prompt_sampling = int(self.batch_prompt_sampling_optionmenu_var.get())
@@ -3353,6 +3406,52 @@ class App(ctk.CTk):
             else:
                 batBase += ' "--model_variant=depth2img" '
 
+        if self.masked_training == True:
+            if export == 'Linux':
+                batBase += ' --masked_training '
+            else:
+                batBase += ' "--masked_training" '
+
+        if self.normalize_masked_area_loss == True:
+            if export == 'Linux':
+                batBase += ' --normalize_masked_area_loss '
+            else:
+                batBase += ' "--normalize_masked_area_loss" '
+
+        try:
+            # if unmasked_probability is a percentage calculate what epoch to stop at
+            if '%' in self.unmasked_probability:
+                percent = float(self.unmasked_probability.replace('%', ''))
+                fraction = percent / 100
+                if export == 'Linux':
+                    batBase += f' --unmasked_probability={fraction}'
+                else:
+                    batBase += f' "--unmasked_probability={fraction}" '
+            elif '%' not in self.unmasked_probability and self.unmasked_probability.strip() != '' and self.unmasked_probability != '0':
+                if export == 'Linux':
+                    batBase += f' --unmasked_probability={self.unmasked_probability}'
+                else:
+                    batBase += f' "--unmasked_probability={self.unmasked_probability}" '
+        except:
+            pass
+
+        try:
+            # if max_denoising_strength is a percentage calculate what epoch to stop at
+            if '%' in self.max_denoising_strength:
+                percent = float(self.max_denoising_strength.replace('%', ''))
+                fraction = percent / 100
+                if export == 'Linux':
+                    batBase += f' --max_denoising_strength={fraction}'
+                else:
+                    batBase += f' "--max_denoising_strength={fraction}" '
+            elif '%' not in self.max_denoising_strength and self.max_denoising_strength.strip() != '' and self.max_denoising_strength != '0':
+                if export == 'Linux':
+                    batBase += f' --max_denoising_strength={self.max_denoising_strength}'
+                else:
+                    batBase += f' "--max_denoising_strength={self.max_denoising_strength}" '
+        except:
+            pass
+
         if self.fallback_mask_prompt != '':
             if export == 'Linux':
                 batBase += f' --add_mask_prompt="{self.fallback_mask_prompt}"'
@@ -3383,7 +3482,7 @@ class App(ctk.CTk):
                     batBase += f' --stop_text_encoder_training={stop_epoch}'
                 else:
                     batBase += f' "--stop_text_encoder_training={stop_epoch}" '
-            elif '%' not in self.limit_text_encoder and self.limit_text_encoder != '' and self.limit_text_encoder != ' ' and self.limit_text_encoder != '0':
+            elif '%' not in self.limit_text_encoder and self.limit_text_encoder.strip() != '' and self.limit_text_encoder != '0':
                 if export == 'Linux':
                     batBase += f' --stop_text_encoder_training={self.limit_text_encoder}'
                 else:

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -2471,7 +2471,7 @@ def main():
                                     if args.model_variant == 'inpainting':
                                         images = pipeline(samplePrompt, conditioning_image, mask, height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps).images
                                     if args.model_variant == 'depth2img':
-                                        images = pipeline(samplePrompt,image=test_image, height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps,strength=1.0).images
+                                        images = pipeline(samplePrompt,image=test_image, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps,strength=1.0).images
                                     elif args.model_variant == 'base':
                                         images = pipeline(samplePrompt,height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps).images
                                     images[0].save(os.path.join(sample_dir,sampleName, f"{sampleName}_{i}.png"))
@@ -2481,7 +2481,7 @@ def main():
                                     if args.model_variant == 'inpainting':
                                         images = pipeline(samplePrompt,conditioning_image, mask,height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps, generator=generator).images
                                     if args.model_variant == 'depth2img':
-                                        images = pipeline(samplePrompt,image=test_image, height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps,generator=generator,strength=1.0).images
+                                        images = pipeline(samplePrompt,image=test_image, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps,generator=generator,strength=1.0).images
                                     elif args.model_variant == 'base':
                                         images = pipeline(samplePrompt,height=height,width=width, guidance_scale=args.save_guidance_scale, num_inference_steps=args.save_infer_steps, generator=generator).images
                                     images[0].save(os.path.join(sample_dir,sampleName, f"{sampleName}_controlled_seed_{str(seed)}.png"))

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -379,7 +379,11 @@ def parse_args():
     parser.add_argument('--append_sample_controlled_seed_action', action='append')
     parser.add_argument('--add_sample_prompt', type=str, action='append')
     parser.add_argument('--use_image_names_as_captions', default=False, action="store_true")
-    parser.add_argument('--add_mask_prompt', type=str, default=None, action="append", dest="mask_prompts")
+    parser.add_argument("--masked_training", default=False, required=False, action='store_true', help="Whether to mask parts of the image during training")
+    parser.add_argument("--normalize_masked_area_loss", default=False, required=False, action='store_true', help="Normalize the loss, to make it independent of the size of the masked area")
+    parser.add_argument("--unmasked_probability", type=float, default=1, required=False, help="Probability of training a step without a mask")
+    parser.add_argument("--max_denoising_strength", type=float, default=1, required=False, help="Max denoising steps to train on")
+    parser.add_argument('--add_mask_prompt', type=str, default=None, action="append", dest="mask_prompts", help="Prompt for automatic mask creation")
     args = parser.parse_args()
     env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
     if env_local_rank != -1 and env_local_rank != args.local_rank:
@@ -697,6 +701,7 @@ class AutoBucketing(Dataset):
                     model_variant='base',
                     extra_module=None,
                     mask_prompts=None,
+                    load_mask=False,
                     ):
         
         self.debug_level = debug_level
@@ -755,6 +760,7 @@ class AutoBucketing(Dataset):
          model_variant=self.model_variant,
          extra_module=self.extra_module,
          mask_prompts=mask_prompts,
+         load_mask=load_mask,
         )
 
         #print(self.image_train_items)
@@ -811,8 +817,8 @@ class AutoBucketing(Dataset):
             image_train_tmp_image = Image.fromarray(self.normalize8(image_train_tmp.image)).convert("RGB")
             
             example["instance_images"] = self.image_transforms(image_train_tmp_image)
-            if self.model_variant == 'inpainting':
-                image_train_tmp_mask = Image.fromarray(self.normalize8(image_train_tmp.extra)).convert("L")
+            if image_train_tmp.mask is not None:
+                image_train_tmp_mask = Image.fromarray(self.normalize8(image_train_tmp.mask)).convert("L")
                 example["mask"] = self.mask_transforms(image_train_tmp_mask)
             if self.model_variant == 'depth2img':
                 image_train_tmp_depth = Image.fromarray(self.normalize8(image_train_tmp.extra)).convert("L")
@@ -848,12 +854,13 @@ class ImageTrainItem():
     """
     image: Image
     mask: Image
+    extra: Image
     identifier: caption,
     target_aspect: (width, height), 
     pathname: path to image file
     flip_p: probability of flipping image (0.0 to 1.0)
     """    
-    def __init__(self, image: Image, extra: Image, caption: str, target_wh: list, pathname: str, flip_p=0.0, model_variant='base'):
+    def __init__(self, image: Image, mask: Image, extra: Image, caption: str, target_wh: list, pathname: str, flip_p=0.0, model_variant='base', load_mask=False):
         self.caption = caption
         self.target_wh = target_wh
         self.pathname = pathname
@@ -863,22 +870,18 @@ class ImageTrainItem():
         self.flip = transforms.RandomHorizontalFlip(p=flip_p)
         self.cropped_img = None
         self.model_variant = model_variant
+        self.load_mask=load_mask
         self.is_dupe = []
         self.variant_warning = False
 
-        if image is None:
-            self.image = []
-        else:
-            self.image = image
-
-        if extra is None:
-            self.extra = []
-        else:
-            self.extra = extra
+        self.image = image
+        self.mask = mask
+        self.extra = extra
 
     def self_destruct(self):
-        self.image = []
-        self.extra = []
+        self.image = None
+        self.mask = None
+        self.extra = None
         self.cropped_img = None
         self.is_dupe.append(1)
 
@@ -944,7 +947,7 @@ class ImageTrainItem():
         crop_jitter: randomly shift cropp by N pixels when using multiple aspect ratios to improve training quality
         """
 
-        if not hasattr(self, 'image') or len(self.image) == 0:
+        if self.image is None:
             chance = float(len(self.is_dupe)) / 10.0
             
             flip_p = self.flip_p + chance if chance < 1.0 else 1.0
@@ -956,14 +959,16 @@ class ImageTrainItem():
             jitter_amount = random.randint(0, crop_jitter)
 
             self.image = self.load_image(self.pathname, crop, jitter_amount, flip)
-            if self.model_variant == "inpainting":
+
+            if self.model_variant == "inpainting" or self.load_mask:
                 if os.path.exists(self.mask_pathname):
-                    self.extra = self.load_image(self.mask_pathname, crop, jitter_amount, flip)
+                    self.mask = self.load_image(self.mask_pathname, crop, jitter_amount, flip)
                 else:
                     if self.variant_warning == False:
                         print(f" {bcolors.FAIL} ** Warning: No mask found for an image, using an empty mask but make sure you're training the right model variant.{bcolors.ENDC}")
                         self.variant_warning = True
-                    self.extra = Image.new('RGB', self.image.size, color="white").convert("L")
+                    self.mask = Image.new('RGB', self.image.size, color="white").convert("L")
+
             if self.model_variant == "depth2img":
                 if os.path.exists(self.depth_pathname):
                     self.extra = self.load_image(self.depth_pathname, crop, jitter_amount, flip)
@@ -982,11 +987,14 @@ class ImageTrainItem():
             self.image = np.array(self.image).astype(np.uint8)
 
             self.image = (self.image / 127.5 - 1.0).astype(np.float32)
-        if self.model_variant != "base":
-            if type(self.extra) is not np.ndarray:
-                self.extra = np.array(self.extra).astype(np.uint8)
+        if self.mask is not None and type(self.mask) is not np.ndarray:
+            self.mask = np.array(self.mask).astype(np.uint8)
 
-                self.extra = (self.extra / 255.0).astype(np.float32)
+            self.mask = (self.mask / 255.0).astype(np.float32)
+        if self.extra is not None and type(self.extra) is not np.ndarray:
+            self.extra = np.array(self.extra).astype(np.uint8)
+
+            self.extra = (self.extra / 255.0).astype(np.float32)
 
         #print(self.image.shape)
 
@@ -1017,6 +1025,7 @@ class DataLoaderMultiAspect():
             model_variant='base',
             extra_module=None,
             mask_prompts=None,
+            load_mask=False,
     ):
         self.resolution = resolution
         self.debug_level = debug_level
@@ -1031,6 +1040,7 @@ class DataLoaderMultiAspect():
         self.seed = seed
         self.model_variant = model_variant
         self.extra_module = extra_module
+        self.load_mask = load_mask
         prepared_train_data = []
         
         self.aspects = get_aspect_buckets(resolution)
@@ -1108,7 +1118,7 @@ class DataLoaderMultiAspect():
                 use_image_names_as_captions = False
                 self.class_image_caption_pairs.extend(self.__prescan_images(debug_level, self.class_images_path, flip_p,use_image_names_as_captions,concept_class_prompt,use_text_files_as_captions=self.use_text_files_as_captions))
             self.class_image_caption_pairs = self.__bucketize_images(self.class_image_caption_pairs, batch_size=batch_size, debug_level=debug_level,aspect_mode=self.aspect_mode,action_preference=self.action_preference)
-        if self.model_variant == "inpainting" and mask_prompts is not None:
+        if mask_prompts is not None:
             print(f" {bcolors.WARNING} Checking and generating missing masks...{bcolors.ENDC}")
             clip_seg = ClipSeg()
             clip_seg.mask_images(self.image_paths, mask_prompts)
@@ -1157,7 +1167,7 @@ class DataLoaderMultiAspect():
 
             target_wh = min(self.aspects, key=lambda aspects:abs(aspects[0]/aspects[1] - image_aspect))
 
-            image_train_item = ImageTrainItem(image=None, extra=None, caption=identifier, target_wh=target_wh, pathname=pathname, flip_p=flip_p,model_variant=self.model_variant)
+            image_train_item = ImageTrainItem(image=None, mask=None, extra=None, caption=identifier, target_wh=target_wh, pathname=pathname, flip_p=flip_p,model_variant=self.model_variant, load_mask=self.load_mask)
 
             decorated_image_train_items.append(image_train_item)
         return decorated_image_train_items
@@ -1302,6 +1312,7 @@ class NormalDataset(Dataset):
         model_variant='base',
         extra_module=None,
         mask_prompts=None,
+        load_mask=None,
     ):
         self.use_image_names_as_captions = use_image_names_as_captions
         self.size = size
@@ -1315,6 +1326,7 @@ class NormalDataset(Dataset):
         self.model_variant = model_variant
         self.variant_warning = False
         self.vae_scale_factor = None
+        self.load_mask = load_mask
         for concept in concepts_list:
             if 'use_sub_dirs' in concept:
                 if concept['use_sub_dirs'] == True:
@@ -1330,7 +1342,7 @@ class NormalDataset(Dataset):
             if with_prior_preservation:
                 for i in range(repeats):
                     self.__recurse_data_root(self, concept,use_sub_dirs=False,class_images=True)
-        if self.model_variant == "inpainting" and mask_prompts is not None:
+        if mask_prompts is not None:
             print(f" {bcolors.WARNING} Checking and generating missing masks{bcolors.ENDC}")
             clip_seg = ClipSeg()
             clip_seg.mask_images(self.image_paths, mask_prompts)
@@ -1432,7 +1444,7 @@ class NormalDataset(Dataset):
         instance_path, instance_prompt = self.image_paths[index % self.num_instance_images]
         og_prompt = instance_prompt
         instance_image = Image.open(instance_path)
-        if self.model_variant == "inpainting":
+        if self.load_mask:
 
             mask_pathname = os.path.splitext(instance_path)[0] + "-masklabel.png"
             if os.path.exists(mask_pathname):
@@ -1595,17 +1607,21 @@ class CachedLatentsDataset(Dataset):
         self.cache = torch.load(self.cache_paths[index])
         self.latents = self.cache.latents_cache[0]
         self.tokens = self.cache.tokens_cache[0]
-        self.conditioning_latent_cache = None
         self.extra_cache = None
+        self.mask_cache = None
+        if self.cache.mask_cache is not None:
+            self.mask_cache = self.cache.mask_cache[0]
+        self.mask_mean_cache = None
+        if self.cache.mask_mean_cache is not None:
+            self.mask_mean_cache = self.cache.mask_mean_cache[0]
         if index in self.conditional_indexes:
             self.text_encoder = self.empty_tokens
         else:
             self.text_encoder = self.cache.text_encoder_cache[0]
         if self.model_variant != 'base':
-            self.conditioning_latent_cache = self.cache.conditioning_latent_cache[0]
             self.extra_cache = self.cache.extra_cache[0]
         del self.cache
-        return self.latents, self.text_encoder, self.conditioning_latent_cache, self.extra_cache, self.tokens
+        return self.latents, self.text_encoder, self.mask_cache, self.mask_mean_cache, self.extra_cache, self.tokens
 
     def add_pt_cache(self, cache_path):
         if len(self.cache_paths) == 0:
@@ -1614,22 +1630,24 @@ class CachedLatentsDataset(Dataset):
             self.cache_paths += (cache_path,)
 
 class LatentsDataset(Dataset):
-    def __init__(self, latents_cache=None, text_encoder_cache=None, conditioning_latent_cache=None, extra_cache=None,tokens_cache=None):
+    def __init__(self, latents_cache=None, text_encoder_cache=None, mask_cache=None, mask_mean_cache=None, extra_cache=None,tokens_cache=None):
         self.latents_cache = latents_cache
         self.text_encoder_cache = text_encoder_cache
-        self.conditioning_latent_cache = conditioning_latent_cache
+        self.mask_cache = mask_cache
+        self.mask_mean_cache = mask_mean_cache
         self.extra_cache = extra_cache
         self.tokens_cache = tokens_cache
-    def add_latent(self, latent, text_encoder, cached_conditioning_latent, cached_extra, tokens_cache):
+    def add_latent(self, latent, text_encoder, cached_mask, cached_extra, tokens_cache):
         self.latents_cache.append(latent)
         self.text_encoder_cache.append(text_encoder)
-        self.conditioning_latent_cache.append(cached_conditioning_latent)
+        self.mask_cache.append(cached_mask)
+        self.mask_mean_cache.append(cached_mask.mean())
         self.extra_cache.append(cached_extra)
         self.tokens_cache.append(tokens_cache)
     def __len__(self):
         return len(self.latents_cache)
     def __getitem__(self, index):
-        return self.latents_cache[index], self.text_encoder_cache[index], self.conditioning_latent_cache[index], self.extra_cache[index], self.tokens_cache[index]
+        return self.latents_cache[index], self.text_encoder_cache[index], self.mask_cache[index], self.mask_mean_cache[index], self.extra_cache[index], self.tokens_cache[index]
 class AverageMeter:
     def __init__(self, name=None):
         self.name = name
@@ -1910,6 +1928,7 @@ def main():
             model_variant=args.model_variant,
             extra_module=None if args.model_variant != "depth2img" else d2i,
             mask_prompts=args.mask_prompts,
+            load_mask=args.masked_training,
         )
     else:
         train_dataset = NormalDataset(
@@ -1926,6 +1945,7 @@ def main():
         model_variant=args.model_variant,
         extra_module=None if args.model_variant != "depth2img" else d2i,
         mask_prompts=args.mask_prompts,
+        load_mask=args.masked_training,
     )
     def collate_fn(examples):
         #print(examples)
@@ -1933,7 +1953,8 @@ def main():
         input_ids = [example["instance_prompt_ids"] for example in examples]
         tokens = input_ids
         pixel_values = [example["instance_images"] for example in examples]
-        if args.model_variant == 'inpainting':
+        mask = None
+        if "mask" in examples[0]:
             mask = [example["mask"] for example in examples]
         if args.model_variant == 'depth2img':
             depth = [example["instance_depth_images"] for example in examples]
@@ -1944,11 +1965,12 @@ def main():
         if args.with_prior_preservation:
             input_ids += [example["class_prompt_ids"] for example in examples]
             pixel_values += [example["class_images"] for example in examples]
-            if args.model_variant == 'inpainting':
+            if "mask" in examples[0]:
                 mask += [example["class_mask"] for example in examples]
             if args.model_variant == 'depth2img':
                 depth = [example["class_depth_images"] for example in examples]
-        if args.model_variant == 'inpainting':
+        mask_values = None
+        if mask is not None:
             mask_values = torch.stack(mask)
             mask_values = mask_values.to(memory_format=torch.contiguous_format).float()
         if args.model_variant == 'depth2img':
@@ -1972,25 +1994,17 @@ def main():
             return_tensors="pt",\
             ).input_ids
 
-        if args.model_variant == 'base':
-            batch = {
-                "input_ids": input_ids,
-                "pixel_values": pixel_values,
-                "extra_values": None,
-                "tokens" : tokens
-            }
-        else:
-            if args.model_variant == 'depth2img':
-                extra_values = depth_values
-            elif args.model_variant == 'inpainting':
-                extra_values = mask_values
-            batch = {
-                "input_ids": input_ids,
-                "pixel_values": pixel_values,
-                "extra_values": extra_values,
-                "tokens" : tokens
-            }
-        return batch
+        extra_values = None
+        if args.model_variant == 'depth2img':
+            extra_values = depth_values
+
+        return {
+            "input_ids": input_ids,
+            "pixel_values": pixel_values,
+            "extra_values": extra_values,
+            "mask_values": mask_values,
+            "tokens": tokens
+        }
 
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset, batch_size=args.train_batch_size, shuffle=False, collate_fn=collate_fn, pin_memory=True
@@ -2046,12 +2060,11 @@ def main():
     if not args.train_text_encoder:
         text_encoder.to(accelerator.device, dtype=weight_dtype)
 
-    if args.model_variant == 'inpainting':
-        if args.use_bucketing:
-            wh = set([tuple(x.target_wh) for x in train_dataset.image_train_items])
-        else:
-            wh = set([tuple([args.resolution, args.resolution]) for x in train_dataset.image_paths])
-        extra_latent = {shape: vae.encode(torch.zeros(1, 3, shape[1], shape[0]).to(accelerator.device, dtype=weight_dtype)).latent_dist.mean * 0.18215 for shape in wh}
+    if args.use_bucketing:
+        wh = set([tuple(x.target_wh) for x in train_dataset.image_train_items])
+    else:
+        wh = set([tuple([args.resolution, args.resolution]) for x in train_dataset.image_paths])
+    full_mask_by_aspect = {shape: vae.encode(torch.zeros(1, 3, shape[1], shape[0]).to(accelerator.device, dtype=weight_dtype)).latent_dist.mean * 0.18215 for shape in wh}
 
     cached_dataset = CachedLatentsDataset(batch_size=args.train_batch_size,
     text_encoder=text_encoder,
@@ -2090,38 +2103,38 @@ def main():
     if gen_cache == True:
         #delete all the cached latents if they exist to avoid problems
         print(f" {bcolors.WARNING}Generating latents cache...{bcolors.ENDC}")
-        train_dataset = LatentsDataset([], [], [], [], [])
+        train_dataset = LatentsDataset([], [], [], [], [], [])
         counter = 0
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         with torch.no_grad():
             for batch in tqdm(train_dataloader, desc="Caching latents", bar_format='%s{l_bar}%s%s{bar}%s%s{r_bar}%s'%(bcolors.OKBLUE,bcolors.ENDC, bcolors.OKBLUE, bcolors.ENDC,bcolors.OKBLUE,bcolors.ENDC,)):
-                cached_conditioning_latent = None
                 cached_extra = None
+                cached_mask = None
                 batch["pixel_values"] = batch["pixel_values"].to(accelerator.device, non_blocking=True, dtype=weight_dtype)
                 batch["input_ids"] = batch["input_ids"].to(accelerator.device, non_blocking=True)
+                cached_latent = vae.encode(batch["pixel_values"]).latent_dist
+                if batch["mask_values"] is not None:
+                    cached_mask = functional.resize(batch["mask_values"], size=cached_latent.mean.shape[2:])
                 if args.model_variant == "inpainting":
-                    batch["extra_values"] = batch["extra_values"].to(accelerator.device, non_blocking=True, dtype=weight_dtype)
-                    cached_conditioning_latent = vae.encode(batch["pixel_values"] * (1 - batch["extra_values"])).latent_dist
-                    cached_extra = functional.resize(batch["extra_values"], size=cached_conditioning_latent.mean.shape[2:])
+                    batch["mask_values"] = batch["mask_values"].to(accelerator.device, non_blocking=True, dtype=weight_dtype)
+                    cached_extra = vae.encode(batch["pixel_values"] * (1 - batch["mask_values"])).latent_dist
                 if args.model_variant == "depth2img":
                     batch["extra_values"] = batch["extra_values"].to(accelerator.device, non_blocking=True, dtype=weight_dtype)
-                    cached_conditioning_latent = vae.encode(batch["pixel_values"] * (1 - batch["extra_values"])).latent_dist
-                    cached_extra = functional.resize(batch["extra_values"], size=cached_conditioning_latent.mean.shape[2:])
-                cached_latent = vae.encode(batch["pixel_values"]).latent_dist
+                    cached_extra = functional.resize(batch["extra_values"], size=cached_latent.mean.shape[2:])
                 if args.train_text_encoder:
                     cached_text_enc = batch["input_ids"]
                 else:
                     cached_text_enc = text_encoder(batch["input_ids"])[0]
-                train_dataset.add_latent(cached_latent, cached_text_enc, cached_conditioning_latent, cached_extra, batch["tokens"])
+                train_dataset.add_latent(cached_latent, cached_text_enc, cached_mask, cached_extra, batch["tokens"])
                 del batch
                 del cached_latent
                 del cached_text_enc
-                del cached_conditioning_latent
+                del cached_mask
                 del cached_extra
                 torch.save(train_dataset, os.path.join(latent_cache_dir,f"latents_cache_{counter}.pt"))
                 cached_dataset.add_pt_cache(os.path.join(latent_cache_dir,f"latents_cache_{counter}.pt"))
                 counter += 1
-                train_dataset = LatentsDataset([], [], [], [], [])
+                train_dataset = LatentsDataset([], [], [], [], [], [])
                 #if counter % 300 == 0:
                     #train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=1, collate_fn=lambda x: x, shuffle=False)
                 #    gc.collect()
@@ -2645,19 +2658,20 @@ def main():
 
                         latent_dist = batch[0][0]
                         latents = latent_dist.sample() * 0.18215
+                        mask = batch[0][2]
+                        mask_mean = batch[0][3]
                         if args.model_variant == 'inpainting':
-                            conditioning_latent_dist = batch[0][2]
-                            mask = batch[0][3]
+                            conditioning_latent_dist = batch[0][4]
                             conditioning_latents = conditioning_latent_dist.sample() * 0.18215
                         if args.model_variant == 'depth2img':
-                            depth = batch[0][3]
+                            depth = batch[0][4]
                     if args.sample_from_batch > 0:
-                        args.batch_tokens = batch[0][4]
+                        args.batch_tokens = batch[0][5]
                     # Sample noise that we'll add to the latents
                     noise = torch.randn_like(latents)
                     bsz = latents.shape[0]
                     # Sample a random timestep for each image
-                    timesteps = torch.randint(0, noise_scheduler.config.num_train_timesteps, (bsz,), device=latents.device)
+                    timesteps = torch.randint(0, int(noise_scheduler.config.num_train_timesteps * args.max_denoising_strength), (bsz,), device=latents.device)
                     timesteps = timesteps.long()
 
                     # Add noise to the latents according to the noise magnitude at each timestep
@@ -2675,18 +2689,18 @@ def main():
                         else:
                             encoder_hidden_states = batch[0][1]
 
+                    if mask is not None and random.uniform(0, 1) < args.unmasked_probability:
+                        # for some steps, predict the unmasked image
+                        conditioning_latents = torch.stack([full_mask_by_aspect[tuple([latents.shape[3]*8, latents.shape[2]*8])].squeeze()] * bsz)
+                        mask = torch.ones(bsz, 1, latents.shape[2], latents.shape[3]).to(accelerator.device, dtype=weight_dtype)
                     # Predict the noise residual
                     if args.model_variant == 'inpainting':
-                        if random.uniform(0, 1) < 0.25:
-                            # for some steps, predict the unmasked image
-                            conditioning_latents = torch.stack([extra_latent[tuple([latents.shape[3]*8, latents.shape[2]*8])].squeeze()] * bsz)
-                            mask = torch.ones(bsz, 1, latents.shape[2], latents.shape[3]).to(accelerator.device, dtype=weight_dtype)
 
                         noisy_inpaint_latents = torch.concat([noisy_latents, mask, conditioning_latents], 1)
                         model_pred = unet(noisy_inpaint_latents, timesteps, encoder_hidden_states).sample
                     elif args.model_variant == 'depth2img':
-                        noisy_latents = torch.cat([noisy_latents, depth], dim=1)
-                        model_pred = unet(noisy_latents, timesteps, encoder_hidden_states, depth).sample
+                        noisy_depth_latents = torch.cat([noisy_latents, depth], dim=1)
+                        model_pred = unet(noisy_depth_latents, timesteps, encoder_hidden_states, depth).sample
                     elif args.model_variant == "base":
                         model_pred = unet(noisy_latents, timesteps, encoder_hidden_states).sample
                     
@@ -2700,6 +2714,8 @@ def main():
                         raise ValueError(f"Unknown prediction type {noise_scheduler.config.prediction_type}")
                     if args.model_variant == "inpainting":
                         del timesteps, noise, latents, noisy_latents,noisy_inpaint_latents, encoder_hidden_states
+                    elif args.model_variant == "depth2img":
+                        del timesteps, noise, latents, noisy_latents,noisy_depth_latents, encoder_hidden_states
                     elif args.model_variant == "base":
                         del timesteps, noise, latents, noisy_latents, encoder_hidden_states
                     if args.with_prior_preservation:
@@ -2720,12 +2736,28 @@ def main():
                         # Chunk the noise and model_pred into two parts and compute the loss on each part separately.
                         model_pred, model_pred_prior = torch.chunk(model_pred, 2, dim=0)
                         target, target_prior = torch.chunk(target, 2, dim=0)
-                        loss = F.mse_loss(model_pred.float(), target.float(), reduction="none").mean([1, 2, 3]).mean()
-                        prior_loss = F.mse_loss(model_pred_prior.float(), target_prior.float(), reduction="mean")
+                        if mask is not None and args.model_variant != "inpainting":
+                            loss = tu.masked_mse_loss(model_pred.float(), target.float(), mask, reduction="none").mean([1, 2, 3]).mean()
+                            prior_loss = tu.masked_mse_loss(model_pred_prior.float(), target_prior.float(), mask, reduction="mean")
+                        else:
+                            loss = F.mse_loss(model_pred.float(), target.float(), reduction="none").mean([1, 2, 3]).mean()
+                            prior_loss = F.mse_loss(model_pred_prior.float(), target_prior.float(), reduction="mean")
+
                         # Add the prior loss to the instance loss.
                         loss = loss + args.prior_loss_weight * prior_loss
+
+                        if mask is not None and args.normalize_masked_area_loss:
+                            loss = loss / mask_mean
+
                     else:
-                        loss = F.mse_loss(model_pred.float(), target.float(), reduction="mean")
+                        if mask is not None and args.model_variant != "inpainting":
+                            loss = tu.masked_mse_loss(model_pred.float(), target.float(), mask, reduction="none").mean([1, 2, 3])
+                            loss = loss.mean()
+                        else:
+                            loss = F.mse_loss(model_pred.float(), target.float(), reduction="mean")
+
+                        if mask is not None and args.normalize_masked_area_loss:
+                            loss = loss / mask_mean
                     accelerator.backward(loss)
                     if accelerator.sync_gradients:
                         params_to_clip = (

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -2442,8 +2442,8 @@ def main():
                             sampleName = f"prompt_{sampleIndex+1}"
                             os.makedirs(os.path.join(sample_dir,sampleName), exist_ok=True)
                             if args.model_variant == 'inpainting':
-                                conditioning_image = torch.zeros(1, 3, width, height)
-                                mask = torch.ones(1, 1, width, height)
+                                conditioning_image = torch.zeros(1, 3, height, width)
+                                mask = torch.ones(1, 1, height, width)
                             if args.model_variant == 'depth2img':
                                 #pil new white image
                                 test_image = Image.new('RGB', (width, height), (255, 255, 255))

--- a/scripts/trainer_util.py
+++ b/scripts/trainer_util.py
@@ -2,6 +2,7 @@
 from typing import Iterable
 import torch
 import torch.utils.checkpoint
+import torch.nn.functional as F
 from diffusers import DiffusionPipeline
 from torchvision import transforms
 from PIL import Image, ImageFilter
@@ -27,6 +28,11 @@ def exists(val):
 def default(val, d):
     return val if exists(val) else d
 
+
+def masked_mse_loss(predicted, target, mask, reduction="none"):
+    masked_predicted = predicted * mask
+    masked_target = target * mask
+    return F.mse_loss(masked_predicted, masked_target, reduction=reduction)
 
 # flash attention forwards and backwards
 # https://arxiv.org/abs/2205.14135


### PR DESCRIPTION
This PR contains many smaller and bigger changes to support a fully masked training workflow.

The structure of the latent cache has changed a bit. The "extra" data is used for the depth information and the conditioning image for inpainting. I added a new variable for the mask, that can now be used for all models.

Features:
- It is now possible to manually edit the mask in Caption Buddy. The UX is not perfect (it lags for bigger images, and the cursor does not represent the bursh size), but I still think it is better than nothing.
- The fraction of unmasked steps is now configurable, was previously hardcoded at 25%. If you want to make sure that the model does not learn anything outside of the masked area, this should be set to 0%.
- The max amount of denoising steps during training are configurable. The idea behind this is pretty simple. If you task the model to predict the noise in an image that is only noise, it will probably predict something that is not even close to the original image. You might get something that still fits the prompt, but the composition is different. That makes the normal mse loss function useless. If you limit the noise to something like 75%, you will get much closer to the actual image composition. This is especially useful for masked training, where the predicted subject might be completely outside of the original masked area. It can also reduce overfitting.
- A new option to normalize the importance of all masked images. (Idea taken from https://twitter.com/cloneofsimo/status/1608454983661551616). Basically means, images with smaller masks are trained just as much as images with bigger masks. This is very useful if you want to train on images where the subject does not have the same size in all images. Like a person where some images are closups and other images are full body shots.
- And the biggest one: Training on masked images is possible for all model types now. This is done by using a modified loss function that only focuses on the masked parts of the image.

Fixes
- The model playground now works with inpainting and depth2img models
- The flip probability was evaluated separately for the image, mask and depth. This could lead to situations where the image was flipped, but the mask was not.
- Some more fixes for bugs I found along the way. Mostly related to inpainting and depth2img training
