### PR TITLE
Support long prompts in the model playground, coincidentally add support for weighted prompts.

### DIFF
--- a/scripts/configuration_gui.py
+++ b/scripts/configuration_gui.py
@@ -2273,7 +2273,7 @@ class App(ctk.CTk):
             self.play_generate_image_button["text"] = "Loading Model, Please stand by..."
             #self.play_generate_image_button.configure(fg="red")
             self.play_generate_image_button.update()
-            self.pipe = diffusers.DiffusionPipeline.from_pretrained(model,torch_dtype=torch.float16,safety_checker=None)
+            self.pipe = diffusers.DiffusionPipeline.from_pretrained(model,custom_pipeline="lpw_stable_diffusion",torch_dtype=torch.float16,safety_checker=None)
             if isinstance(self.pipe, StableDiffusionPipeline):
                 self.play_model_variant = 'base'
             if isinstance(self.pipe, StableDiffusionInpaintPipeline):


### PR DESCRIPTION
We can use the diffusers community pipeline "Long Prompt Weighting Stable Diffusion" to enable prompts longer than 75 tokens long in the model playground.

With this change the new limit is 3 * 75 tokens. It's adjustable by passing in `max_embeddings_multiples`, The default is 3.

This pipeline also adds support for weighted tokens, if that's an issue it can be turned off via `skip_parsing=True`, It does change the behavior of parenthesis and square brackets if its enabled, see documentation below.
```
    Parses a string with attention tokens and returns a list of pairs: text and its associated weight.
    Accepted tokens are:
      (abc) - increases attention to abc by a multiplier of 1.1
      (abc:3.12) - increases attention to abc by a multiplier of 3.12
      [abc] - decreases attention to abc by a multiplier of 1.1
      \( - literal character '('
      \[ - literal character '['
      \) - literal character ')'
      \] - literal character ']'
      \\ - literal character '\'
      anything else - just text
```