### PR TITLE
fixed custom conda path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,42 @@
-
 <p align="center">
     <br>
     <img src="https://i.imgur.com/uqO9rAd.png" width="800"/>
     <br>
 <p>
 
- 
 # Stable Tuner, Fine-tune your SD
+
 <a href='https://ko-fi.com/O4O5GU04F' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi2.png?v=3' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a> <a href='https://discord.gg/DahNECrBUZ' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://cincydiscord.com/wp-content/uploads/2019/02/CINCYDISCORDJOIN.png' border='0' alt='Join the discord :)' /></a>
 
-
 [![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/36Z4ETFZx94/0.jpg)](https://www.youtube.com/watch?v=36Z4ETFZx94)
-  
-### Join the Discord for training and chill ;) 
+
+### Join the Discord for training and chill ;)
+
 Stable Tuner wants to be the easiest and most complete Stable Diffusion tuner :)
 
 Features
-* **For End Users** - ST was made to provide a solution that is convenient but powerful on windows, if you wanted to try finetuning, there's no better option, for Linux folks, a bash script will be added at a later date if there's enough interest.
-* **More models, more fun** - ST Now supports Depth2Img and Inpainting models training!
-* **Your Training, Everywhere** - ST Now supports cloud training as well!, package up your data and start training on Runpod/Colab etc with a few clicks!
-* **Easy Installation** - ST makes installing convenient, using a bat file, ST will setup an environment ready for work and will install all the necessary components to get your training started fast!
-* **Friendly GUI** - ST features a full GUI to configure training runs, import and export settings, view tool tips for options, test your new model in the playground, convert the model to CKPT and more!
-* **Better Performance** - Using Diffusers, Xformers, CUDNN 1.8 and Bitsandbytes along with Latent caching allows for higher batch sizes and faster speeds, higher batch sizes = better quality model!.
-* **A Toolbox** - Use Caption Buddy to quickly generate and edit captions for your dataset in one streamlined tool, ST is building a toolbox for the must-have tools if you're training models.
-* **Fine Tuning Mindset** - ST is built to fine-tune, unlike Dreambooth, ST is meant to fine-tune a model, providing tools and settings to make most of your 3090/4090s, Dreambooth is still an option.
-* **Filename/Caption/Token based learning** - You can train using the individual file names as caption, use a caption txt file or a single token DB style, for finetuning file name and captions are best. 
-* **Aspect Ratio Bucketing** - Using Aspect Ratio bucketing you can use any aspect ratio or resolution for your training images, images will get shuffled into buckets and resized to your chosen resolution target!, supports up to 1024 resolution!.
-* **Remote monitoring using Telegram** - Want to keep tabs on your training? set a bot up in Telegram and receive samples and notifications as you train,  
-* **Better Sampling controls** - To gauge how your model is doing sampling is important, to that effect ST gives you the option to add sample prompts as you see fit, set the number of images to produce per prompt, send a controlled seed prompt (to gauge how a seed changes) or even use random aspect ratios to see how buckets are changing your generations!.
-* **Better Dataset Handling** - Use Dataset balancing to even out multiple concepts so they don't over-power each other, add class images to dataset to train them directly, override per dataset if necessary.
-* **Quality of life** - Many options to tune the experience to your liking, use save latent caching to avoid regenerating them at every run, use high batch-sizes to maximize training speed and performance, use epochs instead of steps to gauge progress better!.
-* **Built for Diffusers** - ST uses HF's Diffusers library to allow the best and fastest implementations going forward, as of now, training 1.4,1.5,2 and 2-768 work great.
+
+- **For End Users** - ST was made to provide a solution that is convenient but powerful on windows, if you wanted to try finetuning, there's no better option, for Linux folks, a bash script will be added at a later date if there's enough interest.
+- **More models, more fun** - ST Now supports Depth2Img and Inpainting models training!
+- **Your Training, Everywhere** - ST Now supports cloud training as well!, package up your data and start training on Runpod/Colab etc with a few clicks!
+- **Easy Installation** - ST makes installing convenient, using a bat file, ST will setup an environment ready for work and will install all the necessary components to get your training started fast!
+- **Friendly GUI** - ST features a full GUI to configure training runs, import and export settings, view tool tips for options, test your new model in the playground, convert the model to CKPT and more!
+- **Better Performance** - Using Diffusers, Xformers, CUDNN 1.8 and Bitsandbytes along with Latent caching allows for higher batch sizes and faster speeds, higher batch sizes = better quality model!.
+- **A Toolbox** - Use Caption Buddy to quickly generate and edit captions for your dataset in one streamlined tool, ST is building a toolbox for the must-have tools if you're training models.
+- **Fine Tuning Mindset** - ST is built to fine-tune, unlike Dreambooth, ST is meant to fine-tune a model, providing tools and settings to make most of your 3090/4090s, Dreambooth is still an option.
+- **Filename/Caption/Token based learning** - You can train using the individual file names as caption, use a caption txt file or a single token DB style, for finetuning file name and captions are best.
+- **Aspect Ratio Bucketing** - Using Aspect Ratio bucketing you can use any aspect ratio or resolution for your training images, images will get shuffled into buckets and resized to your chosen resolution target!, supports up to 1024 resolution!.
+- **Remote monitoring using Telegram** - Want to keep tabs on your training? set a bot up in Telegram and receive samples and notifications as you train,
+- **Better Sampling controls** - To gauge how your model is doing sampling is important, to that effect ST gives you the option to add sample prompts as you see fit, set the number of images to produce per prompt, send a controlled seed prompt (to gauge how a seed changes) or even use random aspect ratios to see how buckets are changing your generations!.
+- **Better Dataset Handling** - Use Dataset balancing to even out multiple concepts so they don't over-power each other, add class images to dataset to train them directly, override per dataset if necessary.
+- **Quality of life** - Many options to tune the experience to your liking, use save latent caching to avoid regenerating them at every run, use high batch-sizes to maximize training speed and performance, use epochs instead of steps to gauge progress better!.
+- **Built for Diffusers** - ST uses HF's Diffusers library to allow the best and fastest implementations going forward, as of now, training 1.4,1.5,2 and 2-768 work great.
 
 ## Installation
+
 Download and install Anaconda or miniconda and clone this repo, run the install_stabletuner.bat, when finished start the app with the StableTuner.cmd file.
+
+Note: If your anaconda is installed in a directory different from the standard installation directory, please create a text file called custom_conda_path.txt and put the path to your anaconda installation inside before running the install_stabletuner.bat file.
 
 ## CUDNN 8.6
 
@@ -44,20 +47,23 @@ Due to the filesize I can't host the DLLs needed for CUDNN 8.6 on Github, I **st
 To install simply unzip the directory and place in the same directory as StableTuner.cmd, run install_stabletuner.bat and you're good to go!
 
 ## Usage
+
 Refer to the tool tips in the GUI for more information, if you have any questions feel free to ask in the <a href="https://discord.gg/DahNECrBUZ">Discord</a>
 
 ## Kudos
-* Shivam - For the original code and inspiration - A2 License
-* Diffusers - For the latest and greatest implementations - A2 License
-* Everydream - For the Aspect Ratio bucketing - MIT License
-* Sygil.dev - For the environment setup - GAPLV3 License
-* sd_dreambooth_extension - for the bitsandbytes files and install script
-* StabilityAI - For the latest and greatest models
-* The whole SD community - For making this possible
+
+- Shivam - For the original code and inspiration - A2 License
+- Diffusers - For the latest and greatest implementations - A2 License
+- Everydream - For the Aspect Ratio bucketing - MIT License
+- Sygil.dev - For the environment setup - GAPLV3 License
+- sd_dreambooth_extension - for the bitsandbytes files and install script
+- StabilityAI - For the latest and greatest models
+- The whole SD community - For making this possible
 
 ## What's next?
-* Linux support
-* More models
-* Advanced model mixing
-* And more! :D
-* Support me on Ko-Fi and come hang out in Discord to help me decide what's next :)
+
+- Linux support
+- More models
+- Advanced model mixing
+- And more! :D
+- Support me on Ko-Fi and come hang out in Discord to help me decide what's next :)

--- a/StableTuner.cmd
+++ b/StableTuner.cmd
@@ -23,9 +23,9 @@ set v_conda_env_name="ST"
 
 echo Environment name is set as %v_conda_env_name% as per environment.yaml
 
-:: Put the path to conda directory in a file called "custom-conda-path.txt" if it's installed at non-standard path
-IF EXIST custom-conda-path.txt (
-  FOR /F %%i IN (custom-conda-path.txt) DO set v_custom_path=%%i
+:: Put the path to conda directory in a file called "custom_conda_path.txt" if it's installed at non-standard path
+IF EXIST custom_conda_path.txt (
+  FOR /F %%i IN (custom_conda_path.txt) DO set v_custom_path=%%i
 )
 
 set INSTALL_ENV_DIR=%cd%\installer_files\env

--- a/install_stabletuner.bat
+++ b/install_stabletuner.bat
@@ -26,9 +26,9 @@ for /F "tokens=2 delims=: " %%i in (environment.yaml) DO (
 
 echo Environment name is set as %v_conda_env_name% as per environment.yaml
 
-:: Put the path to conda directory in a file called "custom-conda-path.txt" if it's installed at non-standard path
-IF EXIST custom-conda-path.txt (
-  FOR /F %%i IN (custom-conda-path.txt) DO set v_custom_path=%%i
+:: Put the path to conda directory in a file called "custom_conda_path.txt" if it's installed at non-standard path
+IF EXIST custom_conda_path.txt (
+  FOR /F %%i IN (custom_conda_path.txt) DO set v_custom_path=%%i
 )
 
 set INSTALL_ENV_DIR=%cd%\installer_files\env


### PR DESCRIPTION
Windows doesn't allow hyphens in file names. I replaced them w underscores (which are valid). Also added a line in the README.md for anyone else who faces "Anaconda/Miniconda not found errors"