### PR TITLE
Proof of concept shuffle comma separated prompts

### DIFF
--- a/scripts/configuration_gui.py
+++ b/scripts/configuration_gui.py
@@ -880,6 +880,7 @@ class App(ctk.CTk):
         self.concept_list_json_path = "concept_list.json"
         self.save_and_sample_every_x_epochs = 5
         self.train_text_encoder = True
+        self.shuffle_after_nth_comma = 2
         self.use_8bit_adam = True
         self.use_gradient_checkpointing = True
         self.num_class_images = 200
@@ -3565,6 +3566,11 @@ class App(ctk.CTk):
                 batBase += ' --train_text_encoder'
             else:
                 batBase += f' "--train_text_encoder" '
+        if self.shuffle_after_nth_comma:
+            if export == 'Linux':
+                batBase += f' --shuffle_after_nth_comma={self.shuffle_after_nth_comma}'
+            else:
+                batBase += f' "--shuffle_after_nth_comma={self.shuffle_after_nth_comma}" '
         if self.with_prior_loss_preservation == True and self.use_aspect_ratio_bucketing == False:
             if export == 'Linux':
                 batBase += ' --with_prior_preservation'


### PR DESCRIPTION
This is a conversation starter and maybe should be thrown away.

Basic idea:
prompt "A,B,C,D" can be permuted in the middle of training with an optional number of leading comma separated sections not getting permuted.

Anyways, labeled as a POC because there isn't a clear ideal way to do this, or at least this isn't it.
Is this how you want this done? Or doing the shuffling against the actual text and recreating input_ids every time make more sense, or something else entirely?

I'm not familiar with pytorch so I suspect what I added can be optimized.

For danbooruy prompts this improved the dropout behavior of individual words, decreased overfitting of the sample prompt and makes order not matter. I didn't try this on more normal 1.4/1.5 prompts. I imagine it would do something similar.

What is not implemented and would be worth doing is partial prompt dropout, or at least I've seen that done with some of the other training tools.

So a technically working implementation of this with a bunch of asterisks:
* Not wired into the gui, changing shuffle_after_nth_comma is easy enough to validate this experiment
* Has an impact on performance, 10%ish, your mileage may vary. Running on a 3060 12gb.
* Only works with the ",<\w>" comma token, aka comma with optional trailing whitespace.
* Wasn't tested on anything other than well formed comma laden sample prompts.
